### PR TITLE
Remove name prop override for cell renderer

### DIFF
--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -29,7 +29,7 @@ export interface Column<D, K, C, H> {
     headerContainerClassName?: string;
 
     cellRenderer: React.ComponentType<C>;
-    cellRendererParams: (key: K, datum: D, index: number) => Omit<C, 'className' | 'name'>;
+    cellRendererParams: (key: K, datum: D, index: number) => Omit<C, 'className'>;
     cellRendererClassName?: string;
     cellContainerClassName?: string;
 
@@ -169,7 +169,6 @@ function Table<D, K extends string | number, C extends Column<D, K, any, any>>(
                             <Renderer
                                 {...otherProps}
                                 className={_cs(cellRendererClassName, styles.cellComponent)}
-                                name={id}
                             />
                         );
 

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -19,5 +19,4 @@ export interface BaseHeader {
 
 export interface BaseCell {
     className?: string;
-    name: string;
 }


### PR DESCRIPTION
Using the id of column as name field for each individual cell
doesn't make sense. The name field is used by different ui components
(eg. in onChange handler). If such elements are passed as cell renderer
the onChange handler won't work as expected.