### PR TITLE
Only sort/filter options when sortFunction is defined

### DIFF
--- a/src/components/MultiSelectInput/index.tsx
+++ b/src/components/MultiSelectInput/index.tsx
@@ -8,6 +8,8 @@ type Def = { containerClassName?: string };
 type NameType = string | number | undefined;
 type OptionKey = string | number;
 
+// FIXME: the omissions is not correct
+// we need multiple omission for SearchMultiSelectInputProps
 export type Props<
     T extends OptionKey,
     K extends NameType,
@@ -21,16 +23,13 @@ function MultiSelectInput<T extends OptionKey, K extends NameType, O extends obj
     props: Props<T, K, O, P>,
 ) {
     const {
-        name,
         options,
-        totalOptionsCount, // eslint-disable-line no-unused-vars, @typescript-eslint/no-unused-vars
         ...otherProps
     } = props;
 
     return (
         <SearchMultiSelectInput
             {...otherProps}
-            name={name}
             options={options}
             sortFunction={rankedSearchOnList}
             searchOptions={options}

--- a/src/components/SelectInput/index.tsx
+++ b/src/components/SelectInput/index.tsx
@@ -11,8 +11,8 @@ type Def = { containerClassName?: string };
 type OptionKey = string | number;
 type NameType = string | number | undefined;
 
-const emptyList: unknown[] = [];
-
+// FIXME: the omissions is not correct
+// we need multiple omission for SearchMultiSelectInputProps
 export type Props<
     T extends OptionKey,
     K extends NameType,
@@ -26,55 +26,16 @@ function SelectInput<T extends OptionKey, K extends NameType, O extends object, 
     props: Props<T, K, O, P>,
 ) {
     const {
-        name,
         options,
-        labelSelector,
-        nonClearable, // eslint-disable-line no-unused-vars, @typescript-eslint/no-unused-vars
-        onChange, // eslint-disable-line no-unused-vars, @typescript-eslint/no-unused-vars
-        totalOptionsCount, // eslint-disable-line no-unused-vars, @typescript-eslint/no-unused-vars
         ...otherProps
     } = props;
 
-    const [searchInputValue, setSearchInputValue] = React.useState('');
-
-    const searchOptions = React.useMemo(
-        () => rankedSearchOnList(options ?? (emptyList as O[]), searchInputValue, labelSelector),
-        [options, searchInputValue, labelSelector],
-    );
-
-    // NOTE: this looks weird but we need to use typeguard to identify between
-    // different union types (for onChange and nonClearable)
-    // eslint-disable-next-line react/destructuring-assignment
-    if (props.nonClearable) {
-        return (
-            <SearchSelectInput
-                {...otherProps}
-                // eslint-disable-next-line react/destructuring-assignment
-                onChange={props.onChange}
-                // eslint-disable-next-line react/destructuring-assignment
-                nonClearable={props.nonClearable}
-                name={name}
-                options={options}
-                labelSelector={labelSelector}
-                onSearchValueChange={setSearchInputValue}
-                searchOptions={searchOptions}
-                // searchOptionsShownInitially
-            />
-        );
-    }
     return (
         <SearchSelectInput
             {...otherProps}
-            // eslint-disable-next-line react/destructuring-assignment
-            onChange={props.onChange}
-            // eslint-disable-next-line react/destructuring-assignment
-            nonClearable={props.nonClearable}
-            name={name}
             options={options}
-            labelSelector={labelSelector}
-            onSearchValueChange={setSearchInputValue}
-            searchOptions={searchOptions}
-            // searchOptionsShownInitially
+            searchOptions={options}
+            sortFunction={rankedSearchOnList}
         />
     );
 }

--- a/storybook/stories/Calendar.stories.tsx
+++ b/storybook/stories/Calendar.stories.tsx
@@ -16,4 +16,5 @@ const Template: Story<CalendarProps<CalendarDateProps>> = (args) => (
 
 export const Default = Template.bind({});
 Default.args = {
+    initialDate: '2020-10-12',
 };

--- a/storybook/stories/SearchMultiSelectInput.stories.tsx
+++ b/storybook/stories/SearchMultiSelectInput.stories.tsx
@@ -84,6 +84,12 @@ Default.args = {
     value: ['1', '3'],
 };
 
+export const NormalSorting = Template.bind({});
+NormalSorting.args = {
+    value: ['1', '3'],
+    selectedOptionsAtTop: false,
+};
+
 export const Disabled = Template.bind({});
 Disabled.args = {
     value: ['1', '3'],

--- a/storybook/stories/SelectInput.stories.tsx
+++ b/storybook/stories/SelectInput.stories.tsx
@@ -59,6 +59,12 @@ Default.args = {
     ellipsizeOptions: true,
 };
 
+export const NormalSorting = Template.bind({});
+NormalSorting.args = {
+    value: '1',
+    selectedOptionsAtTop: false,
+};
+
 export const Disabled = Template.bind({});
 Disabled.args = {
     value: '1',


### PR DESCRIPTION
- Add prop to not move selected options to the top
- Simplify props for SelectInput and MultiSelectInput

### This PR ensures that there are
- [x] No unnecessary console logs
- [x] No unwanted comments
- [x] No typos
- [x] `yarn typecheck` shows no issue
- [x] `yarn lint` shows no issue

### This PR fixes or updates existing components / utils

- [x] Update / add story to reflect the changes
- [x] Doesn't introduce breaking changes